### PR TITLE
feat: Add campaign retry for failed messages

### DIFF
--- a/src/application/hooks/__tests__/useCampaignStream.test.ts
+++ b/src/application/hooks/__tests__/useCampaignStream.test.ts
@@ -71,10 +71,11 @@ describe('useCampaignStream', () => {
       expect(result.current.result).toBeNull();
     });
 
-    it('should provide startStream, stopStream, and reset functions', () => {
+    it('should provide startStream, retryStream, stopStream, and reset functions', () => {
       const { result } = renderHook(() => useCampaignStream());
 
       expect(typeof result.current.startStream).toBe('function');
+      expect(typeof result.current.retryStream).toBe('function');
       expect(typeof result.current.stopStream).toBe('function');
       expect(typeof result.current.reset).toBe('function');
     });
@@ -445,6 +446,140 @@ describe('useCampaignStream', () => {
       expect(result.current.error).toBeNull();
       expect(result.current.isCompleted).toBe(false);
       expect(result.current.result).toBeNull();
+    });
+  });
+
+  describe('retryStream', () => {
+    it('should set isStreaming to true when starting retry', async () => {
+      const events = [
+        createSSEEvent('campaign_started', { campaign_id: 'camp-retry' }),
+        createSSEEvent('campaign_completed', { campaign_id: 'camp-retry', successful: 1, failed: 0, total_contacts: 1 }),
+      ];
+
+      mockFetch.mockResolvedValue({
+        ok: true,
+        body: createMockReadableStream(events),
+      });
+
+      const { result } = renderHook(() => useCampaignStream());
+
+      act(() => {
+        result.current.retryStream('camp-retry');
+      });
+
+      expect(result.current.isStreaming).toBe(true);
+    });
+
+    it('should call the retry endpoint with POST and no JSON body', async () => {
+      const events = [
+        createSSEEvent('campaign_started', { campaign_id: 'camp-retry' }),
+        createSSEEvent('campaign_completed', { campaign_id: 'camp-retry', successful: 1, failed: 0, total_contacts: 1 }),
+      ];
+
+      mockFetch.mockResolvedValue({
+        ok: true,
+        body: createMockReadableStream(events),
+      });
+
+      const { result } = renderHook(() => useCampaignStream());
+
+      await act(async () => {
+        await result.current.retryStream('camp-retry');
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:8000/prospectio/rest/v1/campaigns/camp-retry/retry/stream',
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({
+            'Accept': 'text/event-stream',
+          }),
+        })
+      );
+
+      // Should NOT have Content-Type or body (no JSON body for retry)
+      const callArgs = mockFetch.mock.calls[0][1];
+      expect(callArgs.body).toBeUndefined();
+      expect(callArgs.headers['Content-Type']).toBeUndefined();
+    });
+
+    it('should process SSE events from retry stream like startStream', async () => {
+      const events = [
+        createSSEEvent('campaign_started', { campaign_id: 'camp-retry' }),
+        createSSEEvent('progress_update', {
+          campaign_id: 'camp-retry',
+          current: 1,
+          total: 2,
+          percentage: 50,
+          current_contact_name: 'Retry Contact',
+        }),
+        createSSEEvent('message_generated', {
+          message_id: 'msg-retry-001',
+          campaign_id: 'camp-retry',
+          contact_id: 'c-retry-001',
+          contact_name: 'Retry Contact',
+          subject: 'Retried Subject',
+          message: 'Retried body',
+          status: 'success',
+          created_at: '2025-01-10T12:00:00Z',
+        }),
+        createSSEEvent('campaign_completed', {
+          campaign_id: 'camp-retry',
+          successful: 1,
+          failed: 1,
+          total_contacts: 2,
+        }),
+      ];
+
+      mockFetch.mockResolvedValue({
+        ok: true,
+        body: createMockReadableStream(events),
+      });
+
+      const onComplete = vi.fn();
+      const { result } = renderHook(() => useCampaignStream({ onComplete }));
+
+      await act(async () => {
+        await result.current.retryStream('camp-retry');
+      });
+
+      await waitFor(() => {
+        expect(result.current.isCompleted).toBe(true);
+      });
+
+      expect(result.current.campaignId).toBe('camp-retry');
+      expect(result.current.messages).toHaveLength(1);
+      expect(result.current.messages[0].contact_name).toBe('Retry Contact');
+      expect(result.current.result).toEqual({
+        campaignId: 'camp-retry',
+        successful: 1,
+        failed: 1,
+        totalContacts: 2,
+      });
+      expect(onComplete).toHaveBeenCalledTimes(1);
+    });
+
+    it('should handle HTTP errors from retry endpoint', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 404,
+        statusText: 'Not Found',
+        json: vi.fn().mockResolvedValue({ detail: 'Campaign not found' }),
+      });
+
+      const onError = vi.fn();
+      const { result } = renderHook(() => useCampaignStream({ onError }));
+
+      await act(async () => {
+        await result.current.retryStream('nonexistent-id');
+      });
+
+      await waitFor(() => {
+        expect(result.current.error).toBe('Campaign not found');
+        expect(result.current.isStreaming).toBe(false);
+      });
+
+      expect(onError).toHaveBeenCalledWith('Campaign not found');
     });
   });
 

--- a/src/application/hooks/useCampaignStream.ts
+++ b/src/application/hooks/useCampaignStream.ts
@@ -308,6 +308,83 @@ export function useCampaignStream(options: UseCampaignStreamOptions = {}) {
     }
   }, [cancelReader, handleEvent]);
 
+  const retryStream = useCallback(async (campaignId: string) => {
+    // Cancel existing reader and abort controller
+    cancelReader();
+    if (abortControllerRef.current) {
+      abortControllerRef.current.abort();
+    }
+    abortControllerRef.current = new AbortController();
+
+    // Reset state with streaming flag
+    setState({ ...INITIAL_STATE, isStreaming: true });
+
+    // Wait for config if not loaded
+    if (!configRef.current) {
+      const config = await new ConfigRepository().getConfig();
+      configRef.current = config;
+    }
+
+    const baseUrl = configRef.current.backendUrl;
+    const url = `${baseUrl}/prospectio/rest/v1/campaigns/${campaignId}/retry/stream`;
+    console.log('[SSE] Starting retry stream to:', url);
+
+    try {
+      const response = await fetch(
+        url,
+        {
+          method: 'POST',
+          headers: {
+            'Accept': 'text/event-stream',
+          },
+          signal: abortControllerRef.current.signal,
+        }
+      );
+
+      console.log('[SSE] Retry response status:', response.status, response.ok);
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({ detail: 'Failed to start campaign retry stream' }));
+        throw new Error(errorData.detail || `HTTP ${response.status}: ${response.statusText}`);
+      }
+
+      const reader = response.body?.getReader();
+      if (!reader) {
+        throw new Error('ReadableStream not supported');
+      }
+
+      // Store reader reference for cleanup
+      readerRef.current = reader;
+
+      const processStream = async () => {
+        try {
+          await readSSEStream(reader, handleEvent);
+        } catch (streamError) {
+          if (streamError instanceof Error && streamError.name === 'AbortError') {
+            return;
+          }
+          console.error('Retry stream error:', streamError);
+          const errorMsg = getErrorMessage(streamError, 'Retry stream error');
+          setState(prev => ({ ...prev, isStreaming: false, error: errorMsg }));
+          optionsRef.current.onError?.(errorMsg);
+        } finally {
+          readerRef.current = null;
+        }
+      };
+
+      processStream();
+
+    } catch (error) {
+      if (error instanceof Error && error.name === 'AbortError') {
+        return;
+      }
+      console.error('Failed to start campaign retry stream:', error);
+      const errorMsg = getErrorMessage(error, 'Failed to start retry stream');
+      setState(prev => ({ ...prev, isStreaming: false, error: errorMsg }));
+      optionsRef.current.onError?.(errorMsg);
+    }
+  }, [cancelReader, handleEvent]);
+
   const stopStream = useCallback(() => {
     cancelReader();
     if (abortControllerRef.current) {
@@ -336,6 +413,7 @@ export function useCampaignStream(options: UseCampaignStreamOptions = {}) {
   return {
     ...state,
     startStream,
+    retryStream,
     stopStream,
     reset,
   };

--- a/src/application/pages/ProspectCampaign.test.tsx
+++ b/src/application/pages/ProspectCampaign.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { renderWithProviders } from '@/test/utils/render';
 import ProspectCampaign from './ProspectCampaign';
 import { http, HttpResponse } from 'msw';
@@ -17,6 +18,7 @@ let mockStreamState = {
   isCompleted: false,
   result: null as any,
   startStream: vi.fn(),
+  retryStream: vi.fn(),
   stopStream: vi.fn(),
   reset: vi.fn(),
 };
@@ -52,6 +54,7 @@ describe('ProspectCampaign', () => {
       isCompleted: false,
       result: null,
       startStream: vi.fn(),
+      retryStream: vi.fn(),
       stopStream: vi.fn(),
       reset: vi.fn(),
     };
@@ -450,6 +453,220 @@ describe('ProspectCampaign', () => {
 
     await waitFor(() => {
       expect(screen.getByText(/Generating message 3\/10 for John Doe/)).toBeInTheDocument();
+    });
+  });
+
+  describe('Retry failed button', () => {
+    const campaignWithFailures = {
+      campaigns: [
+        {
+          id: 'camp-retry',
+          name: 'Retry Campaign',
+          status: 'completed' as const,
+          created_at: '2025-01-15T10:00:00Z',
+          updated_at: '2025-01-15T12:00:00Z',
+          total_contacts: 10,
+          successful: 7,
+          failed: 3,
+        },
+      ],
+      pages: 1,
+    };
+
+    const campaignNoFailures = {
+      campaigns: [
+        {
+          id: 'camp-ok',
+          name: 'Perfect Campaign',
+          status: 'completed' as const,
+          created_at: '2025-01-15T10:00:00Z',
+          updated_at: '2025-01-15T12:00:00Z',
+          total_contacts: 10,
+          successful: 10,
+          failed: 0,
+        },
+      ],
+      pages: 1,
+    };
+
+    const campaignFailed = {
+      campaigns: [
+        {
+          id: 'camp-fail',
+          name: 'Failed Campaign',
+          status: 'failed' as const,
+          created_at: '2025-01-15T10:00:00Z',
+          updated_at: '2025-01-15T12:00:00Z',
+          total_contacts: 10,
+          successful: 5,
+          failed: 5,
+        },
+      ],
+      pages: 1,
+    };
+
+    const campaignInProgress = {
+      campaigns: [
+        {
+          id: 'camp-ip',
+          name: 'In Progress Campaign',
+          status: 'in_progress' as const,
+          created_at: '2025-01-15T10:00:00Z',
+          updated_at: '2025-01-15T12:00:00Z',
+          total_contacts: 10,
+          successful: 3,
+          failed: 2,
+        },
+      ],
+      pages: 1,
+    };
+
+    async function selectCampaign() {
+      const user = userEvent.setup();
+      const trigger = screen.getByRole('combobox');
+      await user.click(trigger);
+      await waitFor(() => {
+        const options = screen.getAllByRole('option');
+        expect(options.length).toBeGreaterThan(0);
+      });
+      const options = screen.getAllByRole('option');
+      await user.click(options[0]);
+    }
+
+    it('should show Retry failed button when campaign has failures and status is completed', async () => {
+      server.use(
+        http.get(`${BASE_URL}/campaigns/:offset/:limit`, () => {
+          return HttpResponse.json(campaignWithFailures);
+        }),
+        http.get(`${BASE_URL}/contacts/new/:offset/:limit`, () => {
+          return HttpResponse.json({ contacts: [], pages: 0 });
+        }),
+        http.get(`${BASE_URL}/campaigns/:campaignId/messages/:offset/:limit`, () => {
+          return HttpResponse.json([]);
+        })
+      );
+
+      renderWithProviders(<ProspectCampaign />);
+
+      await waitFor(() => {
+        expect(screen.getByRole('combobox')).toBeInTheDocument();
+      });
+
+      await selectCampaign();
+
+      await waitFor(() => {
+        expect(screen.getByText('Retry failed')).toBeInTheDocument();
+      });
+    });
+
+    it('should show Retry failed button when campaign status is failed', async () => {
+      server.use(
+        http.get(`${BASE_URL}/campaigns/:offset/:limit`, () => {
+          return HttpResponse.json(campaignFailed);
+        }),
+        http.get(`${BASE_URL}/contacts/new/:offset/:limit`, () => {
+          return HttpResponse.json({ contacts: [], pages: 0 });
+        }),
+        http.get(`${BASE_URL}/campaigns/:campaignId/messages/:offset/:limit`, () => {
+          return HttpResponse.json([]);
+        })
+      );
+
+      renderWithProviders(<ProspectCampaign />);
+
+      await waitFor(() => {
+        expect(screen.getByRole('combobox')).toBeInTheDocument();
+      });
+
+      await selectCampaign();
+
+      await waitFor(() => {
+        expect(screen.getByText('Retry failed')).toBeInTheDocument();
+      });
+    });
+
+    it('should not show Retry failed button when campaign has zero failures', async () => {
+      server.use(
+        http.get(`${BASE_URL}/campaigns/:offset/:limit`, () => {
+          return HttpResponse.json(campaignNoFailures);
+        }),
+        http.get(`${BASE_URL}/contacts/new/:offset/:limit`, () => {
+          return HttpResponse.json({ contacts: [], pages: 0 });
+        }),
+        http.get(`${BASE_URL}/campaigns/:campaignId/messages/:offset/:limit`, () => {
+          return HttpResponse.json([]);
+        })
+      );
+
+      renderWithProviders(<ProspectCampaign />);
+
+      await waitFor(() => {
+        expect(screen.getByRole('combobox')).toBeInTheDocument();
+      });
+
+      await selectCampaign();
+
+      // Campaign name appears in select trigger and detail header
+      await waitFor(() => {
+        expect(screen.getAllByText('Perfect Campaign').length).toBeGreaterThanOrEqual(1);
+      });
+
+      expect(screen.queryByText('Retry failed')).not.toBeInTheDocument();
+    });
+
+    it('should not show Retry failed button when campaign is in_progress', async () => {
+      server.use(
+        http.get(`${BASE_URL}/campaigns/:offset/:limit`, () => {
+          return HttpResponse.json(campaignInProgress);
+        }),
+        http.get(`${BASE_URL}/contacts/new/:offset/:limit`, () => {
+          return HttpResponse.json({ contacts: [], pages: 0 });
+        }),
+        http.get(`${BASE_URL}/campaigns/:campaignId/messages/:offset/:limit`, () => {
+          return HttpResponse.json([]);
+        })
+      );
+
+      renderWithProviders(<ProspectCampaign />);
+
+      await waitFor(() => {
+        expect(screen.getByRole('combobox')).toBeInTheDocument();
+      });
+
+      await selectCampaign();
+
+      // Campaign name appears in select trigger and detail header
+      await waitFor(() => {
+        expect(screen.getAllByText('In Progress Campaign').length).toBeGreaterThanOrEqual(1);
+      });
+
+      expect(screen.queryByText('Retry failed')).not.toBeInTheDocument();
+    });
+
+    it('should not show Retry failed button during streaming', async () => {
+      mockStreamState = {
+        ...mockStreamState,
+        isStreaming: true,
+        campaignId: 'camp-retry',
+      };
+
+      server.use(
+        http.get(`${BASE_URL}/campaigns/:offset/:limit`, () => {
+          return HttpResponse.json(campaignWithFailures);
+        }),
+        http.get(`${BASE_URL}/contacts/new/:offset/:limit`, () => {
+          return HttpResponse.json({ contacts: [], pages: 0 });
+        })
+      );
+
+      renderWithProviders(<ProspectCampaign />);
+
+      await waitFor(() => {
+        expect(screen.getByRole('combobox')).toBeInTheDocument();
+      });
+
+      // During streaming, the campaign detail section is hidden (isGenerating check)
+      expect(screen.queryByText('Retry failed')).not.toBeInTheDocument();
     });
   });
 });

--- a/src/application/pages/ProspectCampaign.tsx
+++ b/src/application/pages/ProspectCampaign.tsx
@@ -20,6 +20,7 @@ import {
   Calendar,
   Clock,
   Zap,
+  RotateCcw,
 } from 'lucide-react';
 import { motion, AnimatePresence, useReducedMotion } from 'framer-motion';
 import { AnimatedPage } from '@/application/components/layout/animated-page';
@@ -98,6 +99,7 @@ export default function ProspectCampaign() {
     isCompleted: streamCompleted,
     result: streamResult,
     startStream,
+    retryStream,
   } = useCampaignStream({
     onComplete: (result) => {
       toast({
@@ -232,6 +234,15 @@ export default function ProspectCampaign() {
     toast({
       title: "Campaign Generation Started",
       description: `Creating "${campaignName}" with personalized messages...`,
+    });
+  };
+
+  const handleRetryCampaign = () => {
+    if (!selectedCampaign) return;
+    retryStream(selectedCampaign.id);
+    toast({
+      title: "Retry Started",
+      description: `Retrying failed messages for "${selectedCampaign.name}"...`,
     });
   };
 
@@ -490,6 +501,20 @@ export default function ProspectCampaign() {
                           <div className="text-xs text-muted-foreground uppercase">Failed</div>
                         </div>
                       </div>
+                      {/* Retry Failed Button */}
+                      {selectedCampaign.failed > 0 &&
+                        (selectedCampaign.status === 'completed' || selectedCampaign.status === 'failed') &&
+                        !isStreaming && (
+                          <AnimatedButton
+                            variant="outline"
+                            size="sm"
+                            onClick={handleRetryCampaign}
+                            className="ml-4 border-red-300 text-red-600 hover:bg-red-50 hover:text-red-700 dark:border-red-700 dark:text-red-400 dark:hover:bg-red-900/20 dark:hover:text-red-300"
+                          >
+                            <RotateCcw className="h-4 w-4 mr-2" />
+                            Retry failed
+                          </AnimatedButton>
+                      )}
                     </div>
                   </div>
                 </AnimatedCardContent>

--- a/src/infrastructure/services/backendApiService.ts
+++ b/src/infrastructure/services/backendApiService.ts
@@ -297,6 +297,15 @@ export class BackendApiService {
   }
 
   /**
+   * Get the SSE stream URL for retrying failed campaign messages
+   * @param campaignId - The campaign ID to retry
+   * @returns Full URL for the retry stream endpoint
+   */
+  async getRetryCampaignStreamUrl(campaignId: string): Promise<string> {
+    return `${(await this.config).backendUrl}/prospectio/rest/v1/campaigns/${campaignId}/retry/stream`;
+  }
+
+  /**
    * Generate campaign messages for all new contacts with a specific campaign name
    * @param name - The name for the new campaign
    * @returns Task object with task_id to poll for status

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -43,6 +43,14 @@ Object.defineProperty(window, 'matchMedia', {
   }),
 });
 
+// Mock pointer capture methods for Radix UI components
+Element.prototype.hasPointerCapture = Element.prototype.hasPointerCapture || (() => false);
+Element.prototype.setPointerCapture = Element.prototype.setPointerCapture || (() => {});
+Element.prototype.releasePointerCapture = Element.prototype.releasePointerCapture || (() => {});
+
+// Mock scrollIntoView for Radix UI components
+Element.prototype.scrollIntoView = Element.prototype.scrollIntoView || (() => {});
+
 // Mock ResizeObserver
 global.ResizeObserver = class ResizeObserver {
   observe() {}


### PR DESCRIPTION
## Summary
- Add `retryStream(campaignId)` function to `useCampaignStream` hook that sends a POST to `/campaigns/{id}/retry/stream` and reuses all existing SSE parsing/event handling logic
- Add `getRetryCampaignStreamUrl` method to `BackendApiService`
- Add "Retry failed" button in the campaign detail panel, visible only when `failed > 0` and campaign status is `completed` or `failed` and no streaming is active
- Add pointer capture polyfills to test setup for Radix UI Select compatibility in jsdom

## Test plan
- [x] 5 new tests for retry button visibility (shown on completed/failed with failures, hidden on zero failures, hidden on in_progress, hidden during streaming)
- [x] 4 new tests for `retryStream` hook (sets streaming state, calls correct endpoint with POST/no body, processes SSE events, handles HTTP errors)
- [x] All 363 existing tests pass
- [x] Build passes